### PR TITLE
search-uiの依存関係を修正（streamlit>=1.20.0）

### DIFF
--- a/part2/app/search-ui/Dockerfile
+++ b/part2/app/search-ui/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.7
-RUN pip install elasticsearch~=7.17 streamlit>=1.20.0
+RUN pip install elasticsearch~=7.17 streamlit==1.20.0
 
 WORKDIR /app
 COPY search-ui/ .

--- a/part2/app/search-ui/Dockerfile
+++ b/part2/app/search-ui/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.7
-RUN pip install elasticsearch~=7.17 streamlit==1.17.0
+RUN pip install elasticsearch~=7.17 streamlit>=1.20.0
 
 WORKDIR /app
 COPY search-ui/ .


### PR DESCRIPTION
[StreamlitTeamの公式回答](https://discuss.streamlit.io/t/modulenotfounderror-no-module-named-altair-vegalite-v4/42921/13)に従い、streamlitの依存を `>=1.20.0` に変更しました。